### PR TITLE
feat: migrate code-review to Workflow (adversarial verify pass) [#10]

### DIFF
--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -1,9 +1,11 @@
 ---
-description: Run intelligent, multi-specialist code review. Analyzes changes, spawns focused review specialists (security, architecture, SOLID, code quality, tests, etc.), consolidates findings. Invoke via /agenticaiplugin:code-review.
+description: Run intelligent, multi-specialist code review. Analyzes changes, spawns focused review specialists (security, architecture, SOLID, code quality, tests, etc.), adversarially verifies findings, consolidates. Invoke via /agenticaiplugin:code-review.
 effort: xhigh
 ---
 
-Multi-specialist code review. You are the **Chief Architect** orchestrating 11 focused review specialists.
+Multi-specialist code review. You are the **Chief Architect**. Orchestration runs as a
+deterministic `Workflow` script (`review.workflow.js`) that detects findings, runs an
+**adversarial verify pass** to drop false positives, and consolidates deterministically.
 
 Specialists only collect findings — they never fix code.
 
@@ -37,47 +39,95 @@ Specialists only collect findings — they never fix code.
 
 ## Execution Flow
 
-### Step 1: Determine Mode & Get Files
+The orchestration is a `Workflow` script. **This instruction is the opt-in** to call the
+`Workflow` tool. The script is sandboxed (no file/shell access), so YOU gather all inputs
+before the call and write the report after it. See `docs/workflow-integration-howto.md`.
+
+### Step 1: Determine Mode & Gather Inputs (you do this — the script cannot)
+
+Resolve `{skill_dir}` = absolute path of this skill's directory. The script is at
+`{skill_dir}/review.workflow.js`.
 
 **Git Diff (no parameter):**
-1. Get changed files:
-   ```bash
-   git diff --name-only HEAD
-   git diff --name-only --staged
-   git ls-files --others --exclude-standard
-   ```
-   Combine all three lists (deduplicated) into the file list.
-2. **WAIT for step 1 to complete.** If no changes found: display "No uncommitted changes detected" and STOP.
-3. **Only after step 1 succeeds:** Get combined diff: `git diff HEAD` (includes both staged and unstaged changes)
+1. `git diff --name-only HEAD`, `git diff --name-only --staged`, `git ls-files --others --exclude-standard` → combine, dedupe → `files`.
+2. If no changes: display "No uncommitted changes detected" and STOP.
+3. `git diff HEAD` → `diff` (staged + unstaged).
 
-**Single File:** Validate file exists. If not found: error and STOP.
+**Single File:** validate the file exists (else error + STOP); `files = [path]`, `diff = null`, `mode = "single-file"`.
 
-**--complete:** Find all source files (exclude node_modules, target, build, .git, dist, venv, __pycache__).
+**--complete:** find all source files (exclude `node_modules`, `target`, `build`, `.git`, `dist`, `venv`, `__pycache__`) → `files`, `diff = null`, `mode = "complete"`.
 
-**--renovate:** See "Dependency Audit Flow" section in `orchestration.md`. Runs only Specialist 1 in expanded mode against ALL project dependencies.
+**--renovate:** `mode = "renovate"`. Detect manifest files via Glob (patterns in `shared/known-deprecations.md`) → `manifests`. If none: error + STOP. If `--stack` given but not detected: error + STOP. Set `flags = { stack?, quick?, save? }`.
 
-### Steps 2-7: Orchestration (Git Diff / Single File / --complete only)
+**Compute `ctx`** (this makes the activation matrix deterministic in the script):
+- `source`: at least one changed file is a source file (not test/docs/config).
+- `tests`: at least one changed file is a test file.
+- `layers`: number of distinct architectural layers touched (e.g. controller/service/repository/domain/infra, or distinct top-level module dirs). Integer.
+- `newDeps`: a manifest file (pom.xml, build.gradle, package.json, requirements.txt, pyproject.toml, go.mod, …) is among the changed files, or the diff adds dependency entries.
+- `guidelines`: `claudedocs/guidelines/` exists and contains `*.md`.
+- `adrs`: `claudedocs/adrs/` exists and contains `*.md`.
 
-Read `orchestration.md` for the full orchestration playbook:
-- **Step 2:** Categorize files (source, test, config, docs) and analyze change patterns
-- **Step 3:** Select specialists based on activation matrix
-- **Step 4:** Execute Phase 1 — Dependencies & Versions (sequential)
-- **Step 5:** Execute Phase 2 — All applicable specialists (parallel, in ONE message)
-- **Step 6:** Consolidate, deduplicate, and sort findings
-- **Step 7:** Output summary table + full report, save to `claudedocs/code-review-result.md`
+Also set `date` = today's date `YYYY-MM-DD`.
+
+### Step 2: Call the Workflow
+
+Call the `Workflow` tool with:
+- `scriptPath`: `{skill_dir}/review.workflow.js`
+- `args`:
+  ```json
+  {
+    "mode": "diff|single-file|complete|renovate",
+    "skillDir": "{skill_dir}",
+    "files": ["..."],
+    "diff": "<unified diff or null>",
+    "ctx": { "source": true, "tests": false, "layers": 3, "newDeps": false, "guidelines": false, "adrs": false },
+    "flags": { "stack": "js", "quick": false, "save": true },
+    "manifests": ["package.json"],
+    "date": "YYYY-MM-DD"
+  }
+  ```
+
+### Step 3: Render & Save the Report (you do this — the script returned only data)
+
+The script returns structured data: `{ findings, lowConfidence, dropped, activated, perSpecialist, phase1Status, note?, renovate? }`.
+Each finding: `{ severity, file, line, description, rule, fix?, impact?, benefit?, specialist, alsoFlaggedBy?, confidence?, originalSeverity? }`.
+
+- `findings` = verified survivors only → render as the main report.
+- `lowConfidence` = Criticals the verifiers refused to confirm. They are **excluded from the
+  main findings** (so they are not presented as confirmed) but **never silently dropped** —
+  list them in an auditable "Low-confidence (verifiers could not confirm)" section.
+- `dropped` = Warnings the verifiers refuted (verified false positives) — optionally list under
+  an auditable "Dropped" note.
+
+Render the report in the **exact format** from `orchestration.md` (Step 5 summary table +
+Step 6 full report: Critical/Warning/Suggestion with `[File:Line]`, Rule/Fix/Impact/Benefit,
+the Specialist Results table from `perSpecialist`).
+
+- Standard modes → write to `claudedocs/code-review-result.md` (overwrite). Confirm: `Report saved: claudedocs/code-review-result.md`.
+- `--renovate` → display the audit; if `--save`, write to `claudedocs/reports/dependency-audit-{date}.md`.
+- If `note` is present (docs/config-only) → show it and stop.
+
+Do NOT auto-fix. Let the user decide.
+
+### Fallback (if the Workflow feature is unavailable or declined)
+
+Fall back to the prompt-based orchestration in `orchestration.md` (Steps 2–7). It is a
+complete specification of the same activation matrix, phase sequencing, model choice, and
+report format. The only feature unique to the workflow path is the adversarial verify pass.
 
 ## Skill Contents
 
 ```
 skills/code-review/
 ├── SKILL.md                    ← This file (orchestrator command)
-├── orchestration.md            ← Detailed playbook, prompt templates, report format
+├── review.workflow.js          ← Deterministic Workflow orchestration (primary path)
+├── orchestration.md            ← Rules spec + prompt-based fallback, report format, prompt templates
 ├── shared/
 │   ├── issue-classification.md ← Severity definitions (Critical/Warning/Suggestion)
 │   ├── best-practices.md       ← Review quality guidelines
-│   ├── specialist-output-format.md ← Standard output format for specialists
+│   ├── specialist-output-format.md ← Standard output format (mirrored by the script schema)
 │   └── known-deprecations.md   ← Registry APIs, manifest detection, WebSearch patterns
-└── specialists/                ← 11 focused review rule sets
+└── specialists/                ← 11 focused review rule sets (read by the subagents)
     ├── 01-dependencies-versions.md    (Phase 1 — always)
     ├── 02-security-data-safety.md     (Phase 2 — source files)
     ├── 03-architecture-layers.md      (Phase 2 — 3+ layers / new deps)
@@ -96,7 +146,8 @@ skills/code-review/
 - **Project guidelines** (`claudedocs/guidelines/*.md`) always override skill rules
 - **Every specialist researches current standards** (language, framework, libraries) via WebSearch/Context7 before reviewing
 - **Phase 1 → Phase 2** sequencing ensures version context is available to all specialists
-- **Parallel Phase 2** execution minimizes total review time
-- If a specialist fails, the review continues with remaining results
+- **Adversarial verify pass** drops majority-refuted false positives; a refuted *Critical* is never silently dropped (kept as low-confidence)
+- **Deterministic consolidation** (dedup by file:line + description similarity, higher severity wins, severity sort) happens in code
+- If a specialist or verifier fails, the review continues with remaining results
 - After review: display findings, do NOT auto-fix, let user decide
 - Review report is always saved to `claudedocs/code-review-result.md` (overwritten each run)

--- a/skills/code-review/orchestration.md
+++ b/skills/code-review/orchestration.md
@@ -1,6 +1,14 @@
 # Code Review Orchestration Playbook
 
-Detailed orchestration logic for the multi-specialist code review architecture. Referenced by SKILL.md during review execution.
+Detailed orchestration logic for the multi-specialist code review architecture.
+
+> **Primary path is the Workflow script `review.workflow.js`** (see `SKILL.md` and
+> `docs/workflow-integration-howto.md`). The script is **authoritative for control flow**:
+> activation matrix, phase sequencing, model choice, the adversarial verify pass, and
+> deterministic dedup/sort. This document remains the **single source of truth for the
+> rules and report format**, and is the **complete prompt-based fallback** used when the
+> Workflow feature is unavailable or declined. Keep the two consistent: if you change
+> activation/model/sequencing, change it in the script and reflect it here.
 
 ## Fundamental Principle: Findings Only
 

--- a/skills/code-review/review.workflow.js
+++ b/skills/code-review/review.workflow.js
@@ -1,0 +1,477 @@
+// Multi-specialist code review — detect -> adversarially verify -> consolidate.
+// Migration of skills/code-review (issue #10) onto the Workflow feature.
+//
+// Integration pattern: docs/workflow-integration-howto.md (spike #9).
+//   - Hook form: globals after meta block, no `export default`, no `input`.
+//   - args arrives as a JSON string -> JSON.parse guard below.
+//   - Sandbox: this script touches NO files. The main model collects inputs
+//     (git diff, ctx, manifests, skillDir, date) before, and writes the report
+//     after. Subagents read rule files via the absolute `skillDir`.
+//   - Failure handling: failed agents resolve to null (no reject) AND are wrapped
+//     in try/catch — both are handled defensively; never `.catch()`-only.
+//
+// Authoritative for: activation matrix, phase sequencing, dedup/sort, verify pass.
+// orchestration.md remains the human-readable spec + prompt-based fallback.
+
+export const meta = {
+  name: "code-review",
+  description: "Multi-specialist code review: detect, adversarially verify, consolidate findings.",
+  phases: [
+    { title: "Phase 1: Dependencies" },
+    { title: "Phase 2: Specialists" },
+    { title: "Verify" },
+    { title: "Consolidate" },
+  ],
+};
+
+const PHASE = {
+  deps: "Phase 1: Dependencies",
+  specialists: "Phase 2: Specialists",
+  verify: "Verify",
+  consolidate: "Consolidate",
+};
+
+// ── Config ───────────────────────────────────────────────────────────────
+const VERIFIERS = 3;                 // odd -> clear majority
+const SEVERITY_ORDER = { Critical: 0, Warning: 1, Suggestion: 2 };
+const VERIFIED_SEVERITIES = ["Critical", "Warning"]; // Suggestions skip verify (cost)
+
+// ── Schemas (mirror shared/specialist-output-format.md + issue-classification.md) ──
+const findingsSchema = {
+  type: "object",
+  required: ["findings"],
+  properties: {
+    specialist: { type: "string" },
+    findings: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["severity", "file", "line", "description", "rule"],
+        properties: {
+          severity: { enum: ["Critical", "Warning", "Suggestion"] },
+          file: { type: "string" },
+          line: { type: "integer" },           // 0 = file-level / not line-specific
+          description: { type: "string" },
+          rule: { type: "string" },            // "{Category} → {Rule}"
+          fix: { type: "string" },             // Critical/Warning
+          impact: { type: "string" },          // Warning
+          benefit: { type: "string" },         // Suggestion
+        },
+      },
+    },
+  },
+};
+
+// Verifier verdict: structured, no free text parsing.
+const verdictSchema = {
+  type: "object",
+  required: ["verdict", "reasoning"],
+  properties: {
+    verdict: { enum: ["confirmed", "refuted", "uncertain"] },
+    reasoning: { type: "string" },
+    corrected_severity: { enum: ["Critical", "Warning", "Suggestion", "drop"] },
+  },
+};
+
+// ── Specialist registry — activation + per-specialist model as real JS logic ──
+// Models 1:1 with orchestration.md "Model selection per specialist".
+const DEP_SPEC = { id: "01", name: "Dependencies & Versions", file: "01-dependencies-versions.md", model: "haiku" };
+const SPECIALISTS = [
+  { id: "02", name: "Security & Data Safety",     file: "02-security-data-safety.md",     model: "opus",   when: (c) => c.source },
+  { id: "03", name: "Architecture & Layers",      file: "03-architecture-layers.md",      model: "opus",   when: (c) => c.source && (c.layers >= 3 || c.newDeps) },
+  { id: "04", name: "Design Patterns (GoF)",      file: "04-design-patterns.md",          model: "haiku",  when: (c) => c.source },
+  { id: "05", name: "SOLID & Code Smells",        file: "05-solid-code-smells.md",        model: "sonnet", when: (c) => c.source },
+  { id: "06", name: "Code Quality & Correctness", file: "06-code-quality-correctness.md", model: "haiku",  when: (c) => c.source },
+  { id: "07", name: "Dead Code & Duplication",    file: "07-dead-code-duplication.md",    model: "haiku",  when: (c) => c.source },
+  { id: "08", name: "Cross-Cutting Concerns",     file: "08-cross-cutting-concerns.md",   model: "sonnet", when: (c) => c.source },
+  { id: "09", name: "Test Quality",               file: "09-test-quality.md",             model: "haiku",  when: (c) => c.tests },
+  { id: "10", name: "Test Completeness & Infra",  file: "10-test-completeness-infra.md",  model: "haiku",  when: (c) => c.source },
+  { id: "11", name: "Documentation & Comments",   file: "11-documentation-comments.md",   model: "haiku",  when: (c) => c.source },
+];
+
+// ── Input (spike #9: args may be a JSON string) ──────────────────────────
+const input = typeof args === "string" ? JSON.parse(args) : (args ?? {});
+const {
+  mode = "diff",
+  skillDir = "skills/code-review",
+  files = [],
+  diff = null,
+  ctx = {},
+  flags = {},
+  manifests = [],
+  date = "",
+} = input;
+
+// ════════════════════════════════════════════════════════════════════════
+// --renovate: single-specialist dependency audit, NO verify pass
+// (findings are registry-verifiable; orchestration.md Dependency Audit Flow).
+// ════════════════════════════════════════════════════════════════════════
+if (mode === "renovate") {
+  phase(PHASE.deps);
+  const out = await safeAgent(
+    buildRenovatePrompt({ skillDir, manifests, flags }),
+    { schema: findingsSchema, model: "haiku", label: "01 Dependency Audit", phase: PHASE.deps }
+  );
+  const findings = tag(out?.findings, DEP_SPEC);
+  return {
+    mode,
+    date,
+    renovate: true,
+    findings: dedupeAndSort(findings),
+    perSpecialist: [{ id: "01", name: DEP_SPEC.name, status: out ? "complete" : "failed", counts: count(findings) }],
+    dropped: [],
+  };
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// Standard review: diff | single-file | complete
+// ════════════════════════════════════════════════════════════════════════
+
+// ── Phase 1: Dependencies & Versions (sequential; context for Phase 2) ──
+phase(PHASE.deps);
+const phase1Out = await safeAgent(
+  buildSpecialistPrompt(DEP_SPEC, { mode, files, diff, ctx, skillDir, phase1Summary: null }),
+  { schema: findingsSchema, model: DEP_SPEC.model, label: "01 Dependencies", phase: PHASE.deps }
+);
+const phase1Findings = tag(phase1Out?.findings, DEP_SPEC);
+const phase1Status = phase1Out ? "complete" : "failed";
+const phase1Summary = summarize(phase1Findings, phase1Status);
+
+// ── Activation as code (orchestration.md Selection Logic) ──
+const active = SPECIALISTS.filter((s) => s.when(ctx));
+
+// Docs/config-only: no Phase 2 specialists (parity with orchestration.md).
+if (!ctx.source && !ctx.tests) {
+  return {
+    mode,
+    date,
+    note: "No code review needed — documentation/config changes only.",
+    findings: dedupeAndSort(phase1Findings),
+    perSpecialist: [specStatus(DEP_SPEC, phase1Status, phase1Findings)],
+    activated: ["01"],
+    dropped: [],
+    phase1Status,
+  };
+}
+
+// ── Phase 2 + Verify as a pipeline: each specialist's findings flow into
+// verification without a global barrier (a fast haiku specialist verifies
+// while a slow opus specialist is still analyzing). ──
+phase(PHASE.specialists);
+const reviewed = await pipeline(
+  active,
+  (spec) => runSpecialist(spec, { mode, files, diff, ctx, skillDir, phase1Summary }), // Stage 1
+  (res) => verifySpecialistFindings(res, { mode, diff, ctx, skillDir })               // Stage 2
+);
+
+// ── Consolidation as deterministic JS (orchestration.md Step 2-4) ──
+phase(PHASE.consolidate);
+const valid = reviewed.filter(Boolean);
+const kept = valid.flatMap((r) => r.kept);
+const lowConf = valid.flatMap((r) => r.lowConf);   // refuted Criticals — excluded from findings, NOT silently dropped
+const dropped = valid.flatMap((r) => r.dropped);   // refuted Warnings — audit trail only
+
+// Main findings = survivors only. Refuted Criticals go to lowConfidence (auditable),
+// refuted Warnings go to dropped (auditable) — neither pollutes the main report.
+const consolidated = dedupeAndSort([...phase1Findings, ...kept]);
+const lowConfidence = dedupeAndSort(lowConf);
+
+const perSpecialist = [
+  specStatus(DEP_SPEC, phase1Status, phase1Findings),
+  ...active.map((spec) => {
+    const r = valid.find((x) => x.spec.id === spec.id);
+    if (!r) return specStatus(spec, "failed", []);
+    return { id: spec.id, name: spec.name, status: r.status, counts: count(r.kept) };
+  }),
+  ...SPECIALISTS.filter((s) => !s.when(ctx)).map((s) => ({ id: s.id, name: s.name, status: "skipped", skipReason: skipReason(s, ctx), counts: count([]) })),
+].sort((a, b) => a.id.localeCompare(b.id));
+
+return {
+  mode,
+  date,
+  findings: consolidated,
+  lowConfidence,           // refuted Criticals (false-negative safety net) — show in an auditable section
+  dropped,                 // refuted Warnings (verified false positives) — audit trail
+  activated: active.map((s) => s.id),
+  perSpecialist,
+  phase1Status,
+};
+
+// ════════════════════════════════════════════════════════════════════════
+// Helpers
+// ════════════════════════════════════════════════════════════════════════
+
+// agent() that never throws and never rejects: null on any failure.
+async function safeAgent(prompt, opts) {
+  try {
+    const out = await agent(prompt, opts);
+    return out ?? null;
+  } catch (e) {
+    log(`agent failed (${opts.label}): ${e?.message ?? e}`);
+    return null;
+  }
+}
+
+async function runSpecialist(spec, c) {
+  const out = await safeAgent(
+    buildSpecialistPrompt(spec, c),
+    { schema: findingsSchema, model: spec.model, label: `${spec.id} ${spec.name}`, phase: PHASE.specialists }
+  );
+  if (!out) return { spec, status: "failed", findings: [] };
+  return { spec, status: "complete", findings: tag(out.findings, spec) };
+}
+
+// Adversarial verify of one specialist's findings. Returns kept/dropped/lowConf.
+async function verifySpecialistFindings(res, c) {
+  const toVerify = res.findings.filter((f) => VERIFIED_SEVERITIES.includes(f.severity));
+  const passthrough = res.findings.filter((f) => !VERIFIED_SEVERITIES.includes(f.severity)); // Suggestions
+
+  const verdicts = await parallel(toVerify.map((f) => () => verifyFinding(f, c)));
+
+  const kept = [...passthrough];
+  const dropped = [];
+  const lowConf = [];
+
+  verdicts.forEach((v, i) => {
+    const f = toVerify[i];
+    if (!v) { kept.push(f); return; }                 // verify failed entirely -> keep finding (no false negative)
+    if (v.survived) {
+      const sev = v.correctedSeverity && v.correctedSeverity !== f.severity ? v.correctedSeverity : f.severity;
+      kept.push({ ...f, severity: sev, ...(sev !== f.severity ? { originalSeverity: f.severity } : {}), confidence: v.confidence });
+    } else if (f.severity === "Critical") {
+      lowConf.push({ ...f, lowConfidence: true, confidence: v.confidence, verdicts: v.verdicts }); // never silently drop a Critical
+    } else {
+      dropped.push({ ...f, confidence: v.confidence, verdicts: v.verdicts });
+    }
+  });
+
+  return { spec: res.spec, status: res.status, kept, dropped, lowConf };
+}
+
+// N independent verifiers try to REFUTE one finding. Survives iff confirmed > refuted.
+async function verifyFinding(f, c) {
+  const model = f.severity === "Critical" ? "opus" : "sonnet";
+  const raw = await parallel(
+    Array.from({ length: VERIFIERS }, () => () =>
+      safeAgent(buildVerifierPrompt(f, c), { schema: verdictSchema, model, label: `verify ${f.file}:${f.line}`, phase: PHASE.verify })
+    )
+  );
+  const ok = raw.filter(Boolean);
+  if (ok.length === 0) return null; // total verify failure -> caller keeps the finding
+  const confirmed = ok.filter((v) => v.verdict === "confirmed").length;
+  const refuted = ok.filter((v) => v.verdict === "refuted").length; // uncertain counts as non-confirmation
+  return {
+    survived: confirmed > refuted,
+    confidence: confirmed / ok.length,
+    verdicts: ok,
+    correctedSeverity: majorityCorrectedSeverity(ok),
+  };
+}
+
+// If a clear majority of verdicts agree on one valid (non-drop) severity, use it.
+function majorityCorrectedSeverity(verdicts) {
+  const tally = {};
+  for (const v of verdicts) {
+    const s = v.corrected_severity;
+    if (!s || s === "drop" || !(s in SEVERITY_ORDER)) continue;
+    tally[s] = (tally[s] || 0) + 1;
+  }
+  let best = null, bestN = 0;
+  for (const [s, n] of Object.entries(tally)) if (n > bestN) { best = s; bestN = n; }
+  return bestN > verdicts.length / 2 ? best : null;
+}
+
+// ── Deterministic dedup + sort (orchestration.md Step 3/4) ──
+// Key = file:line AND description similarity. Higher severity wins; tie-break:
+// more specific rule. Different findings on the same line are NOT merged.
+function dedupeAndSort(findings) {
+  const groups = new Map(); // basename:line -> [merged findings]
+  for (const f of findings) {
+    // Specialists report paths inconsistently (absolute vs relative). Key on the
+    // basename (also the IST report format `[FileName:Line]`) so the same issue
+    // flagged by multiple specialists collapses regardless of path style.
+    const file = basename(f.file);
+    const key = `${file}:${f.line}`;
+    const bucket = groups.get(key) || [];
+    const match = bucket.find((g) => descSimilar(g.description, f.description));
+    if (!match) {
+      bucket.push({ ...f, file, alsoFlaggedBy: [] });
+    } else {
+      const keep = pickFinding(match, f);
+      const other = keep === match ? f : match;
+      Object.assign(match, keep, {
+        file,
+        alsoFlaggedBy: dedupeNames([...(match.alsoFlaggedBy || []), other.specialist]),
+      });
+    }
+    groups.set(key, bucket);
+  }
+  const all = [...groups.values()].flat();
+  return all.sort(
+    (a, b) =>
+      (SEVERITY_ORDER[a.severity] ?? 9) - (SEVERITY_ORDER[b.severity] ?? 9) ||
+      String(a.specialist).localeCompare(String(b.specialist)) ||
+      String(a.file).localeCompare(String(b.file)) ||
+      (a.line || 0) - (b.line || 0)
+  );
+}
+
+function pickFinding(a, b) {
+  const sa = SEVERITY_ORDER[a.severity] ?? 9;
+  const sb = SEVERITY_ORDER[b.severity] ?? 9;
+  if (sa !== sb) return sa < sb ? a : b;        // higher severity wins
+  return ruleSpecificity(b.rule) > ruleSpecificity(a.rule) ? b : a; // tie-break: more specific rule
+}
+function ruleSpecificity(rule) { return (rule || "").includes("→") ? (rule.length + 100) : (rule || "").length; }
+
+function descSimilar(a, b) {
+  const A = tokens(a), B = tokens(b);
+  if (!A.size || !B.size) return true; // no description -> treat same-line as same finding
+  let inter = 0;
+  for (const t of A) if (B.has(t)) inter++;
+  const union = A.size + B.size - inter;
+  return union > 0 && inter / union >= 0.34;
+}
+function tokens(s) {
+  return new Set(String(s || "").toLowerCase().replace(/[^a-z0-9 ]/g, " ").split(/\s+/).filter((w) => w.length > 2));
+}
+function basename(p) { return String(p || "").split(/[\\/]/).pop(); }
+function dedupeNames(a) { return [...new Set(a.filter(Boolean))]; }
+
+function tag(findings, spec) {
+  return (findings || []).map((f) => ({ ...f, specialist: spec.name, specialistId: spec.id }));
+}
+function count(findings) {
+  return {
+    critical: findings.filter((f) => f.severity === "Critical").length,
+    warning: findings.filter((f) => f.severity === "Warning").length,
+    suggestion: findings.filter((f) => f.severity === "Suggestion").length,
+  };
+}
+function specStatus(spec, status, findings) {
+  return { id: spec.id, name: spec.name, status, counts: count(findings) };
+}
+function skipReason(spec, c) {
+  if (spec.id === "03") return "needs 3+ layers or new dependencies";
+  if (spec.id === "09") return "no test files modified";
+  return "no source files modified";
+}
+function summarize(findings, status) {
+  if (status !== "complete") return "Phase 1 (Dependencies & Versions) failed — no version context available.";
+  if (!findings.length) return "Phase 1 found no dependency/version issues.";
+  return findings.map((f) => `- [${f.severity}] ${f.file}:${f.line} ${f.description} (${f.rule})`).join("\n");
+}
+
+// ── Prompt builders (full templates from orchestration.md — research step,
+// rules file, guidelines/ADR override, priority hierarchy all preserved) ──
+function buildSpecialistPrompt(spec, c) {
+  const { mode, files, diff, ctx, skillDir, phase1Summary } = c;
+  return [
+    `You are a code review specialist for [${spec.name}].`,
+    ``,
+    `## Step 1: Research Current Standards`,
+    `BEFORE reviewing any code, identify the project's technology stack from the files`,
+    `and Phase 1 context, then research CURRENT best practices for the detected`,
+    `language(s), framework(s) and their versions, and key libraries. Use WebSearch or`,
+    `Context7 (resolve-library-id -> query-docs) for "[framework] [version] best practices",`,
+    `migration guides (if Phase 1 found an outdated version), and language coding standards.`,
+    `This keeps the review based on up-to-date standards, not outdated patterns.`,
+    ``,
+    `## Step 2: Read Your Rules`,
+    `Read your review rules file: ${skillDir}/specialists/${spec.file}`,
+    `Severity definitions: ${skillDir}/shared/issue-classification.md`,
+    ``,
+    ctx.guidelines
+      ? `## Project Guidelines (OVERRIDE skill rules on conflict)\nRead and apply: claudedocs/guidelines/*.md`
+      : ``,
+    ctx.adrs
+      ? `## Architectural Decision Records\nRead and respect: claudedocs/adrs/*.md — treat ADRs as authoritative; flag code that contradicts documented decisions, and do NOT flag code that conforms to an ADR.`
+      : ``,
+    ``,
+    `## Files to Review`,
+    files.length ? files.map((f) => `- ${f}`).join("\n") : "- (see diff below)",
+    mode === "diff" && diff
+      ? `\n## Review Context (focus on changed lines)\n\`\`\`diff\n${diff}\n\`\`\``
+      : `\n## Review Context\nMode: ${mode}. Read the listed files in full (you have file tools).`,
+    phase1Summary
+      ? `\n## Phase 1 Context (Dependencies & Versions)\n${phase1Summary}\nConsider this when making recommendations.`
+      : ``,
+    ``,
+    `## Instructions`,
+    `1. Identify the tech stack from the files and Phase 1 context.`,
+    `2. Research current standards for the detected language, framework, libraries.`,
+    `3. Read your specialist rules file and the severity definitions.`,
+    `4. Apply your specialist rules AND current technology standards.`,
+    `5. **Priority on conflict:** Project Guidelines > ADRs > Current Standards > Specialist Rules.`,
+    `6. Return findings via the required schema only. severity ∈ {Critical,Warning,Suggestion};`,
+    `   file; line (0 if not line-specific); description (one sentence); rule as "{Category} → {Rule}";`,
+    `   fix for Critical/Warning; impact for Warning; benefit for Suggestion.`,
+    `7. If no issues found, return an empty findings array.`,
+    `8. Do NOT fix code, generate patches, or modify files — findings only.`,
+  ].filter((l) => l !== ``).join("\n");
+}
+
+function buildVerifierPrompt(f, c) {
+  const { mode, diff, ctx, skillDir } = c;
+  return [
+    `You are an adversarial verifier. Another reviewer produced the finding below.`,
+    `Your job is to REFUTE it. Return "confirmed" ONLY if, after a serious attempt to`,
+    `refute it, you cannot. Default to "refuted" when the finding does not hold, and to`,
+    `"uncertain" only when the evidence is genuinely insufficient.`,
+    ``,
+    `## Finding under review`,
+    `- Severity: ${f.severity}`,
+    `- Location: ${f.file}:${f.line}`,
+    `- Description: ${f.description}`,
+    `- Rule: ${f.rule}`,
+    f.fix ? `- Proposed fix: ${f.fix}` : ``,
+    ``,
+    `## How to verify`,
+    `1. Read the actual code at ${f.file} (around line ${f.line}); you have file tools.`,
+    `2. Check the claim against the real code, the diff, and the tech stack.`,
+    ctx.guidelines ? `3. Check claudedocs/guidelines/*.md — a finding that contradicts a project guideline is refuted (or its severity corrected).` : ``,
+    ctx.adrs ? `4. Check claudedocs/adrs/*.md — if the code conforms to a documented ADR, the finding is refuted (false positive).` : ``,
+    `   Severity reference: ${skillDir}/shared/issue-classification.md.`,
+    mode === "diff" && diff ? `\n## Diff context\n\`\`\`diff\n${diff}\n\`\`\`` : ``,
+    ``,
+    `## Common false positives to watch for`,
+    `- "SQL injection" on a query that is in fact parameterized / uses bound parameters.`,
+    `- "Layer violation" that is explicitly sanctioned by an ADR.`,
+    `- "Hardcoded secret" that is a placeholder, test fixture, or example value.`,
+    `- A severity that is too high for the actual impact (use corrected_severity).`,
+    ``,
+    `## Output`,
+    `Return the verdict via the required schema: verdict ∈ {confirmed,refuted,uncertain};`,
+    `reasoning (1-2 sentences); corrected_severity if the finding is real but mis-severitied`,
+    `(or "drop" if it should not appear at all).`,
+  ].filter((l) => l !== ``).join("\n");
+}
+
+function buildRenovatePrompt(c) {
+  const { skillDir, manifests, flags } = c;
+  return [
+    `You are the Dependency Audit specialist. Perform a comprehensive dependency audit`,
+    `for the ENTIRE project (not just changed files).`,
+    ``,
+    `## Your Rules`,
+    `Read: ${skillDir}/specialists/01-dependencies-versions.md`,
+    `## Registry APIs & Manifest Detection`,
+    `Read: ${skillDir}/shared/known-deprecations.md`,
+    `## Severity Definitions`,
+    `Read: ${skillDir}/shared/issue-classification.md`,
+    ``,
+    `## Scope`,
+    `Check ALL dependencies in the project.`,
+    flags.stack ? `Only check ${flags.stack} dependencies.` : ``,
+    flags.quick ? `Skip deprecation research — only check version currency.` : `Also check for deprecated/EOL libraries via WebSearch.`,
+    ``,
+    `## Manifest Files`,
+    manifests.length ? manifests.map((m) => `- ${m}`).join("\n") : `- (detect via the patterns in known-deprecations.md)`,
+    ``,
+    `## Instructions`,
+    `1. Read the manifest file(s) and extract all dependencies.`,
+    `2. For each dependency, verify the latest stable version via the registry API.`,
+    flags.quick ? `` : `3. Use WebSearch to check for deprecated/EOL libraries.`,
+    `4. Return findings via the required schema (Critical/Warning/Suggestion).`,
+  ].filter((l) => l !== ``).join("\n");
+}


### PR DESCRIPTION
## #10 — code-review auf das Workflow-Feature migrieren (mit adversarialem Verify-Pass)

Closes #10. Baut auf dem in #9 (PR #13) festgelegten Pattern auf und etabliert die Skript-/Schema-Konventionen für #11.

### Was sich ändert
Die prompt-gesteuerte Orchestrierung der 11 Spezialisten wird durch ein deterministisches Workflow-Skript `skills/code-review/review.workflow.js` ersetzt. Der eigentliche Mehrwert: ein **adversarialer Verify-Pass**, der False Positives entfernt, bevor sie den Report erreichen.

**Im Code erzwungen (vorher Prompt-Disziplin):**
- **Aktivierungsmatrix als JS-Prädikate** (`source`/`tests`/`layers>=3||newDeps`; docs/config-only → kein Review). Phase 1 (Dependencies) läuft sequenziell vor Phase 2; das Ergebnis wird in jeden Phase-2-Spezialisten injiziert.
- **Phase 2 + Verify als `pipeline`** (schneller Spezialist verifiziert, während langsamer noch läuft). Modellwahl pro Spezialist 1:1 zu `orchestration.md`.
- **Adversarialer Verify-Pass:** Jedes Critical/Warning-Finding stellt sich N=3 unabhängigen Verifiern, die es **widerlegen** sollen; es überlebt nur bei `confirmed > refuted` (`uncertain` = Nicht-Bestätigung). Verifier-Modell skaliert mit Severity.
- **False-Negative-Schutz:** Ein widerlegtes **Critical** wird nie still gedroppt, sondern in eine auditierbare `lowConfidence`-Liste verschoben; widerlegte Warnings → `dropped`.
- **Deterministische Dedup/Sort:** Key = `basename:line` + Description-Ähnlichkeit (Jaccard ≥0.34), höhere Severity gewinnt, „also flagged by" gemergt.
- **Schema-validierte** Findings/Verdicts (kein Freitext-Parsing). Research-Schritt, Guidelines/ADR-Override und Prioritäts-Hierarchie (Guidelines > ADRs > Standards > Rules) in beiden Prompt-Buildern erhalten.
- **Alle Modi:** diff, single-file, complete, renovate (ein Spezialist, kein Verify). Sandbox-sicher: SKILL.md sammelt Inputs (inkl. `ctx`, `skillDir`, `date`) vorher und schreibt `claudedocs/code-review-result.md` nachher.

`orchestration.md` bleibt Regel-Spezifikation + **vollständiger prompt-basierter Fallback** (graceful fallback, wenn das Workflow-Feature nicht verfügbar/abgelehnt ist).

### Tests (real ausgeführt)
**Isolierter Verify-Test** (`agentCount=6`): konstruierter False-Positive (parametrisierte Query als SQLi) → 3× `refuted`, confidence 0; echtes Critical (hardcodierter Key) → 3× `confirmed`, confidence 1. ✅

**End-to-End** auf einem Wegwerf-Repo (`agentCount=51`, diff-Modus):
- Aktivierung exakt deterministisch: `02,04,05,06,07,08,10,11`; `03` übersprungen (`<3 layers`), `09` übersprungen (keine Tests). ✅
- Echtes Critical (hardcodierter Key) überlebt (mehrere Spezialisten, confidence 1). ✅
- Verify entfernte mehrere plausible False Positives: ein **YAGNI-Finding** auf eine *exportierte* Funktion (Critical) → 3× refuted → `lowConfidence`; ein Batch Test-Traceability-/Distribution-Warnings → 3× refuted → `dropped`; darunter eines über `userService.js`, das **gar nicht im Diff** war (Verifier: „file not in diff"). ✅
- **Schwäche gefunden und behoben:** Spezialisten liefern inkonsistente Pfade (absolut vs. relativ) → 3 Critical-Duplikate für denselben Key. Dedup auf `basename`-Key + Schwelle 0.34 umgestellt; deterministisch verifiziert (3 → 1 merged, distinkte Findings bleiben). ✅

### Versionierung
`feat:`-Commit → der projekt-eigene Release-Mechanismus leitet den Bump ab. `plugin.json` unverändert.

### Hinweis
Branch von `master` (nicht von #9), damit der Diff sauber bleibt. Reihenfolge zum Mergen: #9 → #10 → #11.
