### PR TITLE
fix: persona state write never persisted (0.19.2)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agenticaiplugin",
   "description": "A Claude Code productivity toolkit: intelligent code reviews, architecture audits, license compliance checking, QA traceability, smart Git commits, GitHub/npm repository publishing, and agent communication personas.",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "author": {
     "name": "Michael Kagel"
   }

--- a/hooks/persona-inject.sh
+++ b/hooks/persona-inject.sh
@@ -8,10 +8,11 @@
 # behaves exactly as without the plugin.
 #
 # State file (global, per user): ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/persona.state
-# Style snippets:                ${CLAUDE_PLUGIN_ROOT}/skills/persona/styles/<persona>.md
+# Style snippets:                <plugin>/skills/persona/styles/<persona>.md
 #
-# Portability: no absolute/developer-specific paths — only $CLAUDE_CONFIG_DIR,
-# $HOME and $CLAUDE_PLUGIN_ROOT, which Claude Code resolves per environment.
+# Portability: the state path uses only $CLAUDE_CONFIG_DIR/$HOME. The snippet
+# path is resolved by self-location ($BASH_SOURCE), NOT $CLAUDE_PLUGIN_ROOT —
+# that variable is empty in the normal tool context and unreliable here.
 
 set -euo pipefail
 
@@ -34,7 +35,10 @@ case "$persona" in
   "" | off) exit 0 ;;
 esac
 
-snippet="${CLAUDE_PLUGIN_ROOT:-.}/skills/persona/styles/${persona}.md"
+# Resolve the snippet relative to THIS script's own location — robust, does not
+# depend on $CLAUDE_PLUGIN_ROOT (empty/unreliable in this context).
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+snippet="$script_dir/../skills/persona/styles/${persona}.md"
 
 # Unknown / unreadable persona value -> fail safe, inject nothing.
 [ -r "$snippet" ] || exit 0

--- a/skills/persona/SKILL.md
+++ b/skills/persona/SKILL.md
@@ -47,27 +47,35 @@ State file (global, per user): `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/persona.stat
 
 ## Instructions
 
-The persona takes full effect at the next session start (the hook injects it).
-For `set`/`off`, also apply the change immediately for the rest of the current
-session, so the user sees it right away.
+All state changes go through the helper script `persona.sh`. This makes the write
+a **real, verified action** instead of a code block that could be skipped.
 
-Resolve the state file path in every command:
+`{skill_dir}` = the absolute path of THIS skill's directory (resolve it the way
+the other plugin skills do). The script lives at `{skill_dir}/persona.sh`.
 
-```bash
-STATE="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/persona.state"
-```
+> **For `show`, `set`, and `off` you MUST invoke the Bash tool to run the script,
+> then report the persona from its `OK persona=<value>` output line. Do NOT merely
+> display the command, and do NOT fabricate the output: if you did not actually see
+> an `OK persona=...` line in the tool result, the change did NOT happen — say so
+> instead of reporting success.**
+
+The persona also takes effect at the next session start (the hook injects it from
+the state file). For `set`/`off`, additionally apply the change immediately for the
+rest of the current session so the user sees it right away.
 
 ### `show`
 
+Run with the Bash tool:
+
 ```bash
-{ [ -r "$STATE" ] && tr -d '[:space:]' < "$STATE"; } || true
+bash "{skill_dir}/persona.sh" show
 ```
 
-Report `⧉ persona: <value>` — or `⧉ persona: off` if the output is empty.
+From the `OK persona=<value>` line, report `⧉ persona: <value>`.
 
 ### `list`
 
-Output this table verbatim (do not run a command):
+Output this table verbatim (no command needed):
 
 | Persona | Restriction |
 |---------|-------------|
@@ -79,19 +87,25 @@ Output this table verbatim (do not run a command):
 
 ### `off` / `reset`
 
+Run with the Bash tool:
+
 ```bash
-rm -f "$STATE"
+bash "{skill_dir}/persona.sh" off
 ```
 
-Report `⧉ persona: off (updated)`. From now on in this session, respond with
-your normal communication style.
+On `OK persona=off`, report `⧉ persona: off (updated)`, then respond with your
+normal communication style for the rest of this session.
 
 ### `writer` / `engineer` / `telegrapher` / `caveman`
 
+Run with the Bash tool (substitute the chosen persona for `<persona>`):
+
 ```bash
-mkdir -p "$(dirname "$STATE")" && printf '%s\n' "<persona>" > "$STATE"
+bash "{skill_dir}/persona.sh" set <persona>
 ```
 
-Report `⧉ persona: <persona> (updated)`. From now on in this session, apply the
-`<persona>` communication style (writer = decorative/eloquent; engineer =
-concise/factual; telegrapher = brief/abbreviating; caveman = ultra-terse).
+- On `OK persona=<persona>`: report `⧉ persona: <persona> (updated)` and apply that
+  style immediately for the rest of this session (writer = decorative/eloquent;
+  engineer = concise/factual; telegrapher = brief/abbreviating; caveman = ultra-terse).
+- On `ERROR <reason>` (or no `OK` line): report the error and STOP — do not claim
+  the persona was set.

--- a/skills/persona/persona.sh
+++ b/skills/persona/persona.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# agenticaiplugin: persona — state-management CLI
+#
+# Single source of truth for the persona state file. The /agenticaiplugin:persona
+# skill calls this script (it does NOT inline the write) so the state change is a
+# real, verified action instead of a prompt code-block the model might skip.
+#
+# Subcommands:
+#   show        -> prints "OK persona=<value>"  (value is "off" when unset)
+#   set <name>  -> validates, writes atomically, reads back, prints "OK persona=<name>"
+#   off|reset   -> removes the state file,       prints "OK persona=off"
+#
+# Output contract: exactly one line "OK persona=<value>" on success (the skill
+# echoes this back), or "ERROR <reason>" on stderr + non-zero exit on failure.
+#
+# Portability: only $CLAUDE_CONFIG_DIR / $HOME — no absolute or developer paths.
+# The allowed persona values here are the authority; they must match the style
+# snippets in styles/ and the SessionStart hook.
+
+set -euo pipefail
+
+STATE_FILE="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/persona.state"
+VALID="writer engineer telegrapher caveman"
+
+die() { printf 'ERROR %s\n' "$*" >&2; exit 1; }
+
+read_state() {
+  if [ -r "$STATE_FILE" ]; then
+    tr -d '[:space:]' < "$STATE_FILE"
+  fi
+}
+
+cmd="${1:-}"
+case "$cmd" in
+  show)
+    v="$(read_state)"
+    printf 'OK persona=%s\n' "${v:-off}"
+    ;;
+
+  off | reset)
+    rm -f "$STATE_FILE"
+    printf 'OK persona=off\n'
+    ;;
+
+  set)
+    p="${2:-}"
+    [ -n "$p" ] || die "missing persona (expected: $VALID)"
+    valid=0
+    for v in $VALID; do [ "$p" = "$v" ] && valid=1; done
+    [ "$valid" -eq 1 ] || die "invalid persona: '$p' (expected: $VALID)"
+
+    mkdir -p "$(dirname "$STATE_FILE")" || die "cannot create config dir"
+    tmp="${STATE_FILE}.tmp.$$"
+    printf '%s\n' "$p" > "$tmp" || die "cannot write state file"
+    mv -f "$tmp" "$STATE_FILE" || die "cannot move state file into place"
+
+    # read-back verification: only report success if the file really holds $p
+    rb="$(read_state)"
+    [ "$rb" = "$p" ] || die "write verification failed (state holds '$rb')"
+    printf 'OK persona=%s\n' "$rb"
+    ;;
+
+  "" | -h | --help | help)
+    printf 'usage: persona.sh <show|set <persona>|off>\n' >&2
+    printf 'personas: %s\n' "$VALID" >&2
+    exit 2
+    ;;
+
+  *)
+    die "unknown subcommand: '$cmd' (expected: show|set|off)"
+    ;;
+esac

--- a/skills/update-plugin/CHANGELOG.md
+++ b/skills/update-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to the AgenticAI Plugin.
 Format: Machine-readable. Each version is a `## X.Y.Z` section.
 The agent parses this to show the delta between installed and current version.
 
+## 0.19.2
+
+- **persona: make the state write a verified action (bugfix).** The `/agenticaiplugin:persona` skill inlined the state-file write as a shell code block, which the model could treat as illustrative and **skip** — reporting "persona updated" without ever writing `persona.state`. The persona then never persisted (no SessionStart-hook injection next session, no statusline indicator), even though the confirmation claimed success. Fix: state changes now go through a dedicated **`skills/persona/persona.sh`** (`show`/`set`/`off`) with value validation, atomic write (`tmp`+`mv`), read-back verification, and a machine-readable `OK persona=<value>` line the skill must echo back — coupling the confirmation to the real action. `SKILL.md` replaces the inline code blocks with a mandatory, action-oriented script call (`{skill_dir}/persona.sh`) and forbids fabricating the output ("no `OK persona=` line seen → the change did not happen"). The SessionStart hook (`persona-inject.sh`) now resolves its style snippets via `$BASH_SOURCE` self-location instead of `${CLAUDE_PLUGIN_ROOT}` (empty in the normal tool context), so it reliably finds the snippets after the write.
+
 ## 0.19.1
 
 - **code-review & architecture-audit: specialist/analyzer model tiering raised; CR-06 split (#19).** A blind, anchoring-free re-evaluation (18 agents, each scoring one rule file without seeing the assigned model) found the tiering systematically too low — a Critical-recall risk. This release applies the cost-conscious subset of those findings.


### PR DESCRIPTION
## Summary

Bugfix for the `persona` skill (0.19.0): the active persona was **never persisted**.

The skill inlined the state-file write as a shell code block. The model could
treat it as illustrative and skip it — then report "⧉ persona: … (updated)"
without ever writing `persona.state`. Consequences:

- no SessionStart-hook injection in the next session,
- no `☯` indicator in the statusline,

…even though the confirmation claimed success. (Found while dogfooding the feature.)

## Fix

- **`skills/persona/persona.sh`** (new) — single source of truth for the state file: `show` / `set` / `off`, value validation, **atomic write** (`tmp`+`mv`), **read-back verification**, and a machine-readable `OK persona=<value>` line.
- **`SKILL.md`** — replaces the inline code blocks with a **mandatory, action-oriented** script call (`{skill_dir}/persona.sh`). Explicitly forbids fabricating the output: *no `OK persona=` line seen → the change did not happen*. This couples the confirmation to the real action.
- **`hooks/persona-inject.sh`** — resolves its style snippets via **`$BASH_SOURCE` self-location** instead of `${CLAUDE_PLUGIN_ROOT}` (empty/unreliable in the normal tool context), so the hook reliably finds the snippets after the write. Otherwise the fix would be only half-complete.

## Why not just "tell the model harder"

A prompt-based command can never *guarantee* a tool call (that's the root cause here). The fix reduces the skip probability structurally — one named script call instead of three inline snippets, presented as an action rather than an example — and makes a skipped write **immediately visible** via the read-back-coupled `OK persona=` echo. The only watertight alternative would be a mechanism outside the model (MCP/deterministic hook), deliberately out of scope for this opt-in command.

## Tests

17/17 green: `persona.sh` (set/show/off, invalid value leaves state untouched, atomic write, read-back) and the hook **with `CLAUDE_PLUGIN_ROOT` unset** (proves self-location).

## Release

`chore(release): bump plugin to 0.19.2` — patch bump on top of 0.19.1, CHANGELOG entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
