### PR TITLE
fix(ci): quote claude-review allowed-tools to preserve spaces

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -133,5 +133,5 @@ jobs:
 
             Do not invent findings. Be concise. One bullet per issue.
           claude_args: |
-            --allowed-tools Read,Grep,Glob,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh api repos/:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(node --test:*)
+            --allowed-tools "Read,Grep,Glob,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh api repos/:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(node --test:*)"
             --max-turns 25


### PR DESCRIPTION
Fixt einen latenten Bug aus PR #28: In `claude-review.yml` wird der `claude_args`-Block an Leerzeichen tokenisiert, wodurch `--allowed-tools`-Muster mit Leerzeichen (`Bash(node --test:*)`, `Bash(gh pr view:*)`) zerrissen werden. Das mit `--` beginnende Fragment `--test:*)` wird dann als unbekannte CLI-Option gelesen → das Review bricht hart ab (`error: unknown option '--test:*)'`).

Sichtbar wurde das erst beim ersten PR, auf dem das Review tatsächlich lief (die Workflow-einführenden PRs überspringen ihr eigenes Review). Fix: den `--allowed-tools`-Wert in doppelte Anführungszeichen setzen, damit er ein einziges Argument bleibt.

Dieser PR wird bewusst separat gehalten, damit der eigentliche autoskill-PR (#29) danach ohne Workflow-Änderung ein **echtes** Review gegen den reparierten master bekommt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)