### PR TITLE
chore(autoskill): remove archive-layout leftovers, document curator sandbox

### DIFF
--- a/hooks/autoskill/count.mjs
+++ b/hooks/autoskill/count.mjs
@@ -39,7 +39,7 @@ function skillFromPath(np) {
 }
 
 function bumpUsage(skill) {
-  if (!skill || skill === '.archive') return;
+  if (!skill) return;
   const usageFile = join(STATE_DIR, 'usage.json');
   const usage = readJson(usageFile) || {};
   const entry = usage[skill] && typeof usage[skill] === 'object' ? usage[skill] : {};

--- a/hooks/autoskill/prompts/curator.md
+++ b/hooks/autoskill/prompts/curator.md
@@ -3,7 +3,9 @@ the CONTEXT section below. You have READ-ONLY access — do not attempt writes.
 
 Tasks:
 
-1. Glob the library for `*/SKILL.md` and Read each one (skip `.archive/`).
+1. Glob the library for `*/SKILL.md` and Read each one. (Archived skills live
+   outside the library, under the autoskill state dir, so they never appear
+   here.)
 2. Identify OVERLAPS: skills that cover the same class of task, duplicate
    guidance, or should be one umbrella skill with support files.
 3. Identify QUALITY issues: descriptions over 60 characters, session-artifact

--- a/hooks/autoskill/run-review.mjs
+++ b/hooks/autoskill/run-review.mjs
@@ -349,6 +349,12 @@ function curatorMode(model) {
 --- CONTEXT ---
 Skill library directory: ${SKILLS_DIR}
 Learned skills (only these are subject to lifecycle/merge proposals): ${learned.join(' ')}`;
+    // Intentionally lighter sandbox than reviewMode: the curator is READ-ONLY
+    // (no Write/Edit in the allowlist), so it needs neither the staging path
+    // cage / read-before-write guard nor an explicit deny list — its output
+    // only feeds the report, it never touches the skill library. reviewMode
+    // gets the extra --settings/read-guard/acceptEdits layers precisely
+    // because it is allowed to Write.
     const { rc, out } = runClaude(prompt, [
       '--model', model,
       '--output-format', 'text',


### PR DESCRIPTION
Reiner autoskill-Cleanup aus den non-blocking Findings des #29-Reviews — getrennt vom Node-Bump gehalten (#34).

- **Totes `.archive`-Guard** entfernt (count.mjs) + `(skip .archive/)`-Hinweis im Curator-Prompt: Archivierte Skills liegen außerhalb der Library (im autoskill-State-Dir); Altlast aus dem Bash-Prototyp-Layout.
- **Kommentar** zur bewusst leichteren, read-only Sandbox im curatorMode vs. reviewMode (read-guard/deny/acceptEdits).

Node-agnostisch; disjunkte Dateien zu #34 → beliebige Merge-Reihenfolge, kein Rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)