### PR TITLE
docs(prereq): fix Linux Node install hint for the 22 baseline

### DIFF
--- a/prerequisites.json
+++ b/prerequisites.json
@@ -7,7 +7,7 @@
       "features": ["persona (communication styles)", "autoskill (self-learning skills)", "all plugin hooks (SessionStart, PostToolUse, Stop, UserPromptSubmit)"],
       "hints": {
         "win32": "winget install OpenJS.NodeJS.LTS  — new shells only: restart Claude Code afterwards",
-        "linux": "sudo apt install nodejs",
+        "linux": "distro packages often lag behind LTS — install Node 22+ via nvm ('nvm install 22') or NodeSource (https://github.com/nodesource/distributions)",
         "darwin": "brew install node"
       }
     },


### PR DESCRIPTION
Folgt der Suggestion aus dem #34-Review: `sudo apt install nodejs` liefert auf gängigen Distros Node 18 (z.B. Ubuntu 24.04) und erfüllt die in #34 angehobene `minMajor: 22`-Schranke nicht mehr. Hint zeigt jetzt auf nvm / NodeSource.

🤖 Generated with [Claude Code](https://claude.com/claude-code)