### PR TITLE
feat(grill-me): add plan/decision stress-test skill

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agenticaiplugin",
   "description": "A Claude Code productivity toolkit: intelligent code reviews, architecture audits, license compliance checking, QA traceability, smart Git commits, GitHub/npm repository publishing, agent communication personas, and self-learning skills.",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "author": {
     "name": "Michael Kagel"
   }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,7 @@ For file naming, frontmatter requirements, progressive disclosure, and template 
 | `/agenticaiplugin:git-smart-commit` | Atomic commits with meaningful messages |
 | `/agenticaiplugin:gitme` | Short alias for git-smart-commit |
 | `/agenticaiplugin:create-cli` | Design CLI parameters and UX |
+| `/agenticaiplugin:grill-me` | Stress-test a plan/decision via a relentless interview |
 | `/agenticaiplugin:markdown-converter` | Convert files to Markdown via markitdown |
 | `/agenticaiplugin:github-publish` | Prepare repo for public GitHub release (README, badges, logo, license, etc.) |
 | `/agenticaiplugin:npm-publish` | End-to-end npm release: cut release (semver bump + CHANGELOG from Conventional Commits) + pre-publish audit (package.json, version sync, tarball, secrets, license) |

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Initialization creates:
 | `architecture-audit` | 7-dimension architecture assessment with A-E ratings |
 | `qa` | Quality Square traceability (requirements, code, test cases, tests) |
 | `create-cli` | Design CLI parameters, flags, and UX |
+| `grill-me` | Stress-test a plan or decision via a relentless one-question-at-a-time interview |
 | `license-check` | Check dependency license compatibility (full scan or `--quick`) |
 | `markdown-converter` | Convert files to Markdown (PDF, Word, images, audio, etc.) |
 | `handover` | Save/load cross-session continuity snapshot (open items, blockers, next steps) with reconciliation against prior state |
@@ -252,6 +253,7 @@ agenticaiplugin/
 │   ├── architecture-audit/      # 7-dimension architecture assessment
 │   ├── code-review/             # 11-specialist code review
 │   ├── create-cli/              # CLI interface design
+│   ├── grill-me/                # Plan/decision stress-test interview
 │   ├── git-smart-commit/        # Intelligent commit creation
 │   ├── github-publish/          # Public release preparation
 │   ├── gitme/                   # Smart commit command alias

--- a/skills/grill-me/SKILL.md
+++ b/skills/grill-me/SKILL.md
@@ -1,0 +1,59 @@
+---
+description: >
+  Relentlessly interview the user to stress-test a plan, design, or decision until
+  you reach shared understanding. Walks the decision tree branch by branch, one
+  question at a time, each with a recommended answer. Stateless — writes nothing.
+  Invoke via /agenticaiplugin:grill-me.
+disable-model-invocation: true
+effort: high
+---
+
+# Grill Me
+
+Stress-test a plan, design, or decision through a relentless one-question-at-a-time
+interview, until you and the user reach a shared understanding. Stateless: nothing is
+written, the only artifact is the sharpened understanding in the conversation.
+
+## Usage
+
+```
+/agenticaiplugin:grill-me [<topic>]
+```
+
+| Mode | Command | Description |
+|------|---------|-------------|
+| **Default** | `/agenticaiplugin:grill-me` | Grills the plan/decision currently in the conversation. If none is evident, ask the user what to grill first. |
+| **With Topic** | `/agenticaiplugin:grill-me caching strategy` | Uses the free-text as the subject of the interview. |
+
+## Argument Handling
+
+**Check BEFORE executing any steps:**
+
+1. **`--help` passed** → Display the Usage section above verbatim, then STOP.
+2. **No argument** → Grill the plan/decision in the current context. If none is
+   evident, ask the user what they want to grill, then proceed.
+3. **Free-text argument** → Use it as the subject of the interview, then proceed.
+
+## Instructions
+
+Interview the user relentlessly about every aspect of the subject until you reach a
+shared understanding. Walk down each branch of the decision tree, resolving
+dependencies between decisions one by one — settle a parent decision before the
+choices that hang off it.
+
+**Rules of the interview:**
+
+- **One question at a time.** Ask a single question, then wait for the answer before
+  continuing. Asking multiple questions at once is bewildering.
+- **Recommend an answer.** For every question, provide your own recommended answer with
+  brief reasoning, so the user reacts to a proposal instead of a blank prompt.
+- **Look up facts, ask only for decisions.** If something can be determined from the
+  environment (filesystem, tools, code, docs), look it up yourself rather than asking.
+  The *decisions* are the user's — put each one to them and wait.
+- **Surface the implicit.** The goal is not fast agreement; it is to make every implicit
+  call explicit, so nothing important is left silently assumed.
+- **Do not act yet.** Do not implement, edit, or commit anything until the user confirms
+  you have reached a shared understanding.
+
+When the tree has been walked and the user confirms, give a concise summary of the
+settled decisions.

--- a/skills/help/SKILL.md
+++ b/skills/help/SKILL.md
@@ -53,6 +53,7 @@ Show the user the following overview:
 | **architecture-audit** | Comprehensive architecture audit: detects patterns, evaluates 7 dimensions (Boundaries, Dependencies, Naming, APIs, Wiring, Visibility), produces a scored report (A-E scale). Options: `--scope <path>` for partial audits |
 | **qa** | Quality Assurance: manages bidirectional traceability between requirements, code, test cases, and tests ("Quality Square"). Analyzes code, extracts requirements, derives test cases, produces gap analysis. Option: `--force-rebuild` |
 | **create-cli** | Designs CLI interfaces: arguments, flags, subcommands, help text, output formats, exit codes, prompts. Produces a compact spec for implementation |
+| **grill-me** | Relentless one-question-at-a-time interview to stress-test a plan or decision until you reach shared understanding. Stateless, manual-only |
 | **license-check** | Checks license compatibility of all dependencies, tools, scripts, and LLM models against the project license. Modes: standard (full scan including transitive deps) or `--quick` (direct dependencies only). Report saved to `claudedocs/license-check-result.md` |
 
 ### Tools

--- a/skills/update-plugin/CHANGELOG.md
+++ b/skills/update-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to the AgenticAI Plugin.
 Format: Machine-readable. Each version is a `## X.Y.Z` section.
 The agent parses this to show the delta between installed and current version.
 
+## 0.23.0
+
+- **New: `grill-me` skill — relentless plan/decision stress-test.** New user-invoked command `/agenticaiplugin:grill-me [<topic>]` that interviews you one question at a time, walking the decision tree branch by branch and recommending an answer for each, until you reach shared understanding. Facts are looked up from the environment; decisions are put to you. Stateless (writes nothing) and manual-only (`disable-model-invocation: true`). Registered in the help overview and the CLAUDE.md command table.
+
 ## 0.22.0
 
 - **New: autoskill — self-learning skills, migrated into the plugin from a standalone Bash prototype.** Autoskill watches your sessions and distills reusable **learned skills** into the user-level library (`~/.claude/skills/learned-*`), so a technique or correction from one session is available in the next. The prototype was Bash+jq (the exact stack that breaks on Windows per #23/#24); this port is Node stdlib only, under the Hook Runtime Policy, so it works on all platforms. **Opt-in by design** (`agenticaiplugin.config.json` → `"autoskill": { "enabled": true }`, default `false`) because the background reviewer spawns headless `claude -p` runs that cost tokens.


### PR DESCRIPTION
## Was

Neuer user-invoked Skill **`/agenticaiplugin:grill-me [<topic>]`**: ein unnachgiebiges Interview, das einen Plan, ein Design oder eine Entscheidung stresstestet, bis ein gemeinsames Verständnis erreicht ist.

## Verhalten

- **Eine Frage pro Runde**, wartet auf Antwort, je Frage eine **empfohlene Antwort**.
- Läuft den **Entscheidungsbaum** Ast für Ast ab, löst Abhängigkeiten einzeln auf.
- **Fakten** werden selbst aus der Umgebung ermittelt; nur **Entscheidungen** kommen an den User.
- **Zustandslos** (schreibt nichts) und **nur manuell** aufrufbar (`disable-model-invocation: true`) — konsistent mit den anderen Command-Skills.

## Änderungen

| Datei | Aktion |
|-------|--------|
| `skills/grill-me/SKILL.md` | neu |
| `skills/help/SKILL.md` | Eintrag in `### Development` |
| `CLAUDE.md` | Command-Tabelle |
| `skills/update-plugin/CHANGELOG.md` | `## 0.23.0` |
| `.claude-plugin/plugin.json` | Version → 0.23.0 |

## Design

Im Vorbild ist die Funktion zweigeteilt (dünne Front-Door delegiert an ein Primitive); hier bewusst **zu einem Skill zusammengeführt** — eine `SKILL.md`, die den vollen Interview-Inhalt selbst trägt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)