### PR TITLE
fix(autoskill): stage reviewer writes outside the write-blocked config dir (v0.23.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agenticaiplugin",
   "description": "A Claude Code productivity toolkit: intelligent code reviews, architecture audits, license compliance checking, QA traceability, smart Git commits, GitHub/npm repository publishing, agent communication personas, and self-learning skills.",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "author": {
     "name": "Michael Kagel"
   }

--- a/docs/plugin-howto.md
+++ b/docs/plugin-howto.md
@@ -296,10 +296,14 @@ tokens.
   update): `${CLAUDE_CONFIG_DIR:-~/.claude}/agenticaiplugin.autoskill/`.
 - **Reviewer sandbox:** the worker generates its reviewer settings file at
   runtime (a static JSON cannot resolve the plugin path) with the read-guard in
-  exec form; the reviewer may only write into `staging/`, and the deterministic
-  install step in `run-review.mjs` is the ONLY code that touches the library —
-  enforcing the `learned-` prefix, `user-invocable: false`, and manifest-based
-  protection of non-learned skills.
+  exec form. The reviewer may only write into a **per-run staging directory that
+  lives OUTSIDE the config dir** — a fresh `0700` `mkdtemp` under the OS temp dir
+  (`prepareStaging()` in `run-review.mjs`), because Claude Code hard-blocks
+  `Write`/`Edit` under `~/.claude/` as a "sensitive file". Do NOT move staging
+  back under `agenticaiplugin.autoskill/` — that silently re-breaks every
+  reviewer write. The deterministic install step in `run-review.mjs` is the ONLY
+  code that touches the library — enforcing the `learned-` prefix,
+  `user-invocable: false`, and manifest-based protection of non-learned skills.
 - **User commands:** `/agenticaiplugin:learn` (targeted distillation) and
   `/agenticaiplugin:curator` (lifecycle + overlap report).
 

--- a/hooks/autoskill/lib.mjs
+++ b/hooks/autoskill/lib.mjs
@@ -34,8 +34,14 @@ export const ARCHIVE_DIR = join(STATE_DIR, 'archive');
 // CONFIG_DIR. In a real review the worker (run-review.prepareStaging) creates a
 // fresh per-run mkdtemp dir (0700, unpredictable) and exports it via
 // AUTOSKILL_STAGING_DIR, so the reviewer and its read-guard child both resolve
-// that exact path here; the fixed default below is only a fallback / test
-// isolation point. Staging is pure scratch: wiped at the start and end of a run.
+// that exact path here. Staging is pure scratch: wiped at the start and end of a
+// run.
+//
+// WARNING: do NOT write to this fixed fallback default directly — always obtain
+// a staging dir from run-review.prepareStaging(). The fixed path is only what
+// the read-guard child resolves to (via the env the worker sets) and a test
+// isolation point; used un-prepared it is a predictable, world-readable, multi-
+// user-shared path (CWE-377) — exactly the weakness prepareStaging() eliminates.
 export const STAGING_DIR =
   process.env.AUTOSKILL_STAGING_DIR || join(tmpdir(), 'agenticaiplugin-autoskill', 'staging');
 

--- a/hooks/autoskill/lib.mjs
+++ b/hooks/autoskill/lib.mjs
@@ -13,7 +13,7 @@
 // runs, so it is strictly opt-in.
 
 import { appendFileSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
-import { homedir } from 'node:os';
+import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 export const CONFIG_DIR = process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude');
@@ -24,6 +24,20 @@ export const STATE_DIR = join(CONFIG_DIR, 'agenticaiplugin.autoskill');
 export const SKILLS_DIR = join(CONFIG_DIR, 'skills');
 export const LEARNED_LIST = join(STATE_DIR, 'learned.list');
 export const ARCHIVE_DIR = join(STATE_DIR, 'archive');
+// The reviewer LLM stages files here via the Write tool — so this MUST live
+// OUTSIDE the Claude config dir. Claude Code hard-blocks Write/Edit to anything
+// under ~/.claude/ as a "sensitive file", independent of --permission-mode or
+// --allowedTools; staging under CONFIG_DIR silently makes every reviewer write
+// fail (the standalone autoskill kept staging in its own state dir for exactly
+// this reason). Everything else — counters, learned.list, logs, and the install
+// target ~/.claude/skills/ — is written with Node fs (no guard) and stays under
+// CONFIG_DIR. In a real review the worker (run-review.prepareStaging) creates a
+// fresh per-run mkdtemp dir (0700, unpredictable) and exports it via
+// AUTOSKILL_STAGING_DIR, so the reviewer and its read-guard child both resolve
+// that exact path here; the fixed default below is only a fallback / test
+// isolation point. Staging is pure scratch: wiped at the start and end of a run.
+export const STAGING_DIR =
+  process.env.AUTOSKILL_STAGING_DIR || join(tmpdir(), 'agenticaiplugin-autoskill', 'staging');
 
 const DEFAULTS = {
   enabled: false,

--- a/hooks/autoskill/lib.test.mjs
+++ b/hooks/autoskill/lib.test.mjs
@@ -3,9 +3,10 @@
 // file on every call, so one fixture dir serves all cases. Run with: node --test
 
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
 import { mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, normalize } from 'node:path';
 import { test } from 'node:test';
 
 const CONFIG_DIR = mkdtempSync(join(tmpdir(), 'autoskill-lib-'));
@@ -56,6 +57,42 @@ test('user values win; non-integer/negative numbers fall back', () => {
   const bad = readConfig();
   assert.equal(bad.threshold, 10, 'negative -> default');
   assert.equal(bad.nudgeInterval, 10, 'non-integer -> default');
+});
+
+test('REGRESSION: STAGING_DIR never lives under the Claude config dir (write-blocked "sensitive" zone)', () => {
+  // Root cause of the v0.22.x rollout bug: staging under ~/.claude/ made every
+  // reviewer Write fail with a "sensitive file" error. STAGING_DIR is computed
+  // at import time from env, so probe it in a child process with a controlled
+  // CLAUDE_CONFIG_DIR. Guards the invariant, not the current path choice.
+  const lib = new URL('./lib.mjs', import.meta.url).href;
+  const probe = (env) => {
+    const code =
+      `import * as m from ${JSON.stringify(lib)};` +
+      `process.stdout.write(JSON.stringify({ staging: m.STAGING_DIR, config: m.CONFIG_DIR }));`;
+    const r = spawnSync(process.execPath, ['--input-type=module', '-e', code], {
+      encoding: 'utf8',
+      env: { ...process.env, ...env },
+    });
+    assert.equal(r.status, 0, r.stderr);
+    return JSON.parse(r.stdout);
+  };
+
+  // A realistic ~/.claude config dir, no staging override.
+  const fakeClaude = join(tmpdir(), 'fake-home', '.claude');
+  const { staging, config } = probe({ CLAUDE_CONFIG_DIR: fakeClaude, AUTOSKILL_STAGING_DIR: '' });
+  assert.equal(config, fakeClaude);
+  assert.ok(
+    !normalize(staging).startsWith(normalize(fakeClaude)),
+    `staging must live OUTSIDE the config dir — got: ${staging}`
+  );
+  assert.ok(
+    !/[/\\]\.claude([/\\]|$)/.test(staging),
+    `staging must not sit under any .claude directory — got: ${staging}`
+  );
+
+  // The override still wins — tests and the escape hatch depend on it.
+  const forced = join(tmpdir(), 'forced-staging');
+  assert.equal(probe({ AUTOSKILL_STAGING_DIR: forced }).staging, forced);
 });
 
 test('reviewerModel is whitelisted to a safe charset (argv injection guard)', () => {

--- a/hooks/autoskill/maybe-review.mjs
+++ b/hooks/autoskill/maybe-review.mjs
@@ -40,7 +40,7 @@ const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 // than 10 min), then O_EXCL-create the lock file: exactly one caller can create
 // it, so the check-and-acquire is a single atomic step. Returns true only for
 // that caller — closes the race where two Stop hooks both see "free" and each
-// spawn a worker that then collides on staging/ and learned.list.
+// spawn a worker that then collides on the staging dir and learned.list.
 function tryTakeLock(mode) {
   try {
     const raw = readFileSync(LOCK_FILE, 'utf8');

--- a/hooks/autoskill/read-guard.mjs
+++ b/hooks/autoskill/read-guard.mjs
@@ -3,9 +3,12 @@
 // session (wired via the runtime-generated reviewer settings file).
 //
 // Enforces two Hermes invariants hard:
-//   1. Path cage: writes only inside the staging directory
-//      (<stateDir>/staging/ — the skill library itself is written by the
-//      deterministic install step in run-review.mjs, never by the LLM)
+//   1. Path cage: writes only inside the staging directory (STAGING_DIR from
+//      lib.mjs — outside the Claude config dir; the skill library itself is
+//      written by the deterministic install step in run-review.mjs, never by
+//      the LLM). Paths are CANONICALIZED before comparison: a lexical prefix
+//      check alone lets a prompt-injected `<staging>/../../etc` slip through
+//      (the raw string starts with the anchor, yet the write escapes the cage).
 //   2. read-before-write: existing files must be Read before Write/Edit
 //
 // Unlike the session hooks this guard is FAIL-CLOSED: input PRESENT but not
@@ -16,8 +19,16 @@
 // allow/deny lists still constrain). PreToolUse always sends JSON in practice.
 
 import { appendFileSync, existsSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
-import { STATE_DIR, normPath, readHookInput } from './lib.mjs';
+import { join, resolve, sep } from 'node:path';
+import { STAGING_DIR, STATE_DIR } from './lib.mjs';
+
+// Canonical, comparable absolute path: resolve() collapses `.`/`..` segments so
+// a traversal cannot masquerade as a staging-prefixed string; case is folded
+// only on case-insensitive Windows (POSIX paths are case-sensitive).
+const canon = (p) => {
+  const r = resolve(p);
+  return process.platform === 'win32' ? r.toLowerCase() : r;
+};
 
 function deny(reason) {
   process.stdout.write(
@@ -57,42 +68,43 @@ function main() {
     : 'unknown';
   const fpath = typeof input.tool_input?.file_path === 'string' ? input.tool_input.file_path : '';
   const readsFile = join(STATE_DIR, `reviewer-reads-${sid}.txt`);
-  const stagingAnchor = `${normPath(join(STATE_DIR, 'staging'))}/`;
+  const stagingRoot = canon(STAGING_DIR);
+  const stagingAnchor = stagingRoot.endsWith(sep) ? stagingRoot : stagingRoot + sep;
 
-  const markRead = (np) => {
+  const markRead = (key) => {
     try {
-      appendFileSync(readsFile, `${np}\n`);
+      appendFileSync(readsFile, `${key}\n`);
     } catch {
       /* best effort */
     }
   };
-  const wasRead = (np) => {
+  const wasRead = (key) => {
     try {
-      return readFileSync(readsFile, 'utf8').split('\n').includes(np);
+      return readFileSync(readsFile, 'utf8').split('\n').includes(key);
     } catch {
       return false;
     }
   };
 
   if (tool === 'Read') {
-    if (fpath) markRead(normPath(fpath));
+    if (fpath) markRead(canon(fpath));
     return;
   }
 
   if (tool === 'Write' || tool === 'Edit') {
     if (!fpath) return;
-    const np = normPath(fpath);
-    if (!np.startsWith(stagingAnchor)) {
+    const cp = canon(fpath);
+    if (cp !== stagingRoot && !cp.startsWith(stagingAnchor)) {
       deny(
-        `autoskill reviewer may only write inside the staging directory (${join(STATE_DIR, 'staging')}) — got: ${fpath}`
+        `autoskill reviewer may only write inside the staging directory (${STAGING_DIR}) — got: ${fpath}`
       );
     }
-    if (existsSync(fpath) && !wasRead(np)) {
+    if (existsSync(fpath) && !wasRead(cp)) {
       deny(`read-before-write: Read ${fpath} before modifying it (autoskill invariant)`);
     }
     // Own writes count as read — the reviewer may refine its freshly staged
     // file with a follow-up Edit.
-    markRead(np);
+    markRead(cp);
   }
 }
 

--- a/hooks/autoskill/read-guard.test.mjs
+++ b/hooks/autoskill/read-guard.test.mjs
@@ -24,7 +24,9 @@ function fixture() {
       return spawnSync(process.execPath, [SCRIPT], {
         encoding: 'utf8',
         input: typeof input === 'string' ? input : JSON.stringify(input),
-        env: { ...process.env, CLAUDE_CONFIG_DIR: configDir },
+        // Point STAGING_DIR at the fixture: production staging lives outside the
+        // config dir, so the guard no longer derives it from CLAUDE_CONFIG_DIR.
+        env: { ...process.env, CLAUDE_CONFIG_DIR: configDir, AUTOSKILL_STAGING_DIR: staging },
       });
     },
   };
@@ -52,6 +54,18 @@ test('Write outside staging is denied (path cage)', () => {
   });
   const d = decision(r);
   assert.equal(d.permissionDecision, 'deny');
+  assert.match(d.permissionDecisionReason, /staging/);
+});
+
+test('REGRESSION: path traversal is denied — a ".." escape prefixed with staging must not pass the cage', () => {
+  const fx = fixture();
+  // A raw (un-normalized) file_path that STARTS WITH the staging anchor yet
+  // resolves outside it. A lexical startsWith() check would wrongly allow this;
+  // canonicalization must catch it. Forward slashes: path.resolve handles both.
+  const escape = `${fx.staging}/../../../../etc/passwd`;
+  const r = fx.run({ session_id: 's1', tool_name: 'Write', tool_input: { file_path: escape } });
+  const d = decision(r);
+  assert.equal(d.permissionDecision, 'deny', 'traversal out of the cage must be denied');
   assert.match(d.permissionDecisionReason, /staging/);
 });
 

--- a/hooks/autoskill/run-review.mjs
+++ b/hooks/autoskill/run-review.mjs
@@ -6,9 +6,10 @@
 // Invocation: node run-review.mjs <review|curator> [transcript_path] [session_id]
 //
 // The reviewer must NOT write into the skill library directly: it writes into
-// <stateDir>/staging/ (enforced by read-guard.mjs via a runtime-generated
-// settings file — a static settings JSON cannot resolve the plugin install
-// path), and THIS script installs staged skills deterministically. Only here
+// STAGING_DIR (lib.mjs — deliberately OUTSIDE the Claude config dir, which
+// Claude Code hard-blocks for writes; enforced by read-guard.mjs via a
+// runtime-generated settings file — a static settings JSON cannot resolve the
+// staging path), and THIS script installs staged skills deterministically. Only here
 // is the library touched: `learned-` prefix and `user-invocable: false` are
 // enforced, non-learned skills are protected via the manifest.
 
@@ -16,6 +17,7 @@ import {
   cpSync,
   existsSync,
   mkdirSync,
+  mkdtempSync,
   readFileSync,
   readdirSync,
   renameSync,
@@ -24,7 +26,7 @@ import {
   appendFileSync,
 } from 'node:fs';
 import { spawnSync } from 'node:child_process';
-import { homedir } from 'node:os';
+import { homedir, tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
@@ -194,26 +196,30 @@ export function installStaged(stagingDir, { skillsDir = SKILLS_DIR, logFn = log 
 
 // ── review mode ─────────────────────────────────────────────────────────────
 
-function reviewMode(transcript, sid, model) {
-  if (!transcript || !existsSync(transcript)) return;
-
-  let digest = '';
-  try {
-    digest = buildDigest(transcript);
-  } catch {
-    return;
+// Fresh, unpredictable, owner-only (0700) staging dir OUTSIDE the config dir.
+// mkdtemp gives per-run isolation — no cross-user collision on the shared temp
+// root (a single machine-global path breaks the second user with EACCES and
+// lets a local attacker read or pre-plant staged skills) and no world-readable
+// content. An explicit AUTOSKILL_STAGING_DIR override (tests / a write-
+// restricted temp dir) is honored and recreated clean. The chosen path is
+// exported via the env so the reviewer's read-guard child cages the very same
+// directory. Exported for tests.
+export function prepareStaging() {
+  let staging = process.env.AUTOSKILL_STAGING_DIR;
+  if (staging) {
+    rmSync(staging, { recursive: true, force: true });
+    mkdirSync(staging, { recursive: true, mode: 0o700 });
+  } else {
+    staging = mkdtempSync(join(tmpdir(), 'agenticaiplugin-autoskill-'));
+    process.env.AUTOSKILL_STAGING_DIR = staging;
   }
-  if (!digest) return;
-  const digestFile = join(STATE_DIR, 'tmp', `digest-${sid}-${process.pid}.txt`);
-  writeFileAtomic(digestFile, `${digest}\n`);
+  return staging;
+}
 
-  const staging = join(STATE_DIR, 'staging');
-  rmSync(staging, { recursive: true, force: true });
-  mkdirSync(staging, { recursive: true });
-
+function buildReviewPrompt(staging, digestFile) {
   const learnedNames = readLearnedList().join(' ');
   const basePrompt = readFileSync(join(SCRIPT_DIR, 'prompts', 'review.md'), 'utf8');
-  const prompt = `${basePrompt}
+  return `${basePrompt}
 
 --- CONTEXT ---
 Skill library directory (READ-ONLY — read existing skills here): ${SKILLS_DIR}
@@ -228,6 +234,23 @@ To MODIFY a learned skill: Read the original from the library, then Write the
 complete updated file(s) under ${join(staging, '<skill-name>')}/ using the same relative
 paths. Staged files are installed into the library after you finish; staged
 directories without a SKILL.md are only installed if the skill already exists.`;
+}
+
+function reviewMode(transcript, sid, model) {
+  if (!transcript || !existsSync(transcript)) return;
+
+  let digest = '';
+  try {
+    digest = buildDigest(transcript);
+  } catch {
+    return;
+  }
+  if (!digest) return;
+  const digestFile = join(STATE_DIR, 'tmp', `digest-${sid}-${process.pid}.txt`);
+  writeFileAtomic(digestFile, `${digest}\n`);
+
+  const staging = prepareStaging();
+  const prompt = buildReviewPrompt(staging, digestFile);
 
   const settingsFile = writeReviewerSettings();
   const { rc, out } = runClaude(prompt, [

--- a/hooks/autoskill/run-review.test.mjs
+++ b/hooks/autoskill/run-review.test.mjs
@@ -15,6 +15,7 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -26,7 +27,7 @@ const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const CONFIG_DIR = mkdtempSync(join(tmpdir(), 'autoskill-worker-'));
 process.env.CLAUDE_CONFIG_DIR = CONFIG_DIR;
 
-const { installStaged, lifecyclePass } = await import('./run-review.mjs');
+const { installStaged, lifecyclePass, prepareStaging } = await import('./run-review.mjs');
 const STATE_DIR = join(CONFIG_DIR, 'agenticaiplugin.autoskill');
 mkdirSync(join(STATE_DIR, 'tmp'), { recursive: true });
 
@@ -39,6 +40,36 @@ function stageSkill(stagingDir, name, frontmatter) {
   writeFileSync(join(dir, 'SKILL.md'), frontmatter);
   return dir;
 }
+
+test('REGRESSION: prepareStaging yields a fresh 0700 temp dir outside the config dir; override honored & wiped clean', () => {
+  const saved = process.env.AUTOSKILL_STAGING_DIR;
+  try {
+    // Default: no override -> per-run mkdtemp, exported to the env so the
+    // read-guard child cages the same dir. Not a fixed, world-readable, shared
+    // path (that broke multi-user hosts and allowed pre-planting staged skills).
+    delete process.env.AUTOSKILL_STAGING_DIR;
+    const s = prepareStaging();
+    assert.ok(existsSync(s), 'staging created');
+    assert.ok(!s.startsWith(CONFIG_DIR), `must live outside the config dir: ${s}`);
+    assert.equal(process.env.AUTOSKILL_STAGING_DIR, s, 'exported for the read-guard child');
+    if (process.platform !== 'win32') {
+      assert.equal(statSync(s).mode & 0o777, 0o700, 'owner-only perms (no world read / pre-plant)');
+    }
+    rmSync(s, { recursive: true, force: true });
+
+    // Override: honored, and any stale content from a prior run is wiped.
+    const override = join(mkdtempSync(join(tmpdir(), 'ovr-')), 'staging');
+    mkdirSync(override, { recursive: true });
+    writeFileSync(join(override, 'stale.txt'), 'old');
+    process.env.AUTOSKILL_STAGING_DIR = override;
+    assert.equal(prepareStaging(), override, 'override honored');
+    assert.equal(existsSync(join(override, 'stale.txt')), false, 'stale content wiped');
+    rmSync(override, { recursive: true, force: true });
+  } finally {
+    if (saved === undefined) delete process.env.AUTOSKILL_STAGING_DIR;
+    else process.env.AUTOSKILL_STAGING_DIR = saved;
+  }
+});
 
 test('installStaged: enforces learned- prefix, patches frontmatter, updates manifest', () => {
   writeFileSync(LEARNED_LIST, '');
@@ -174,6 +205,10 @@ console.log('SUMMARY: Created stub-technique.');
   writeFileSync(transcript, `${JSON.stringify({ type: 'user', message: { content: 'hi' } })}\n`);
   writeFileSync(join(STATE_DIR, 'review.lock'), '1 1 review\n');
 
+  // Staging lives OUTSIDE the config dir in production (sensitive-zone guard);
+  // isolate it per fixture so the run is hermetic and the cleanup check is exact.
+  const stagingScratch = join(mkdtempSync(join(tmpdir(), 'autoskill-e2e-')), 'staging');
+
   const r = spawnSync(
     process.execPath,
     [join(SCRIPT_DIR, 'run-review.mjs'), 'review', transcript, 'e2e'],
@@ -182,6 +217,7 @@ console.log('SUMMARY: Created stub-technique.');
       env: {
         ...process.env,
         CLAUDE_CONFIG_DIR: CONFIG_DIR,
+        AUTOSKILL_STAGING_DIR: stagingScratch,
         AUTOSKILL_REVIEWER: '1',
         PATH: `${binDir}:${process.env.PATH}`,
       },
@@ -198,7 +234,8 @@ console.log('SUMMARY: Created stub-technique.');
     /Created stub-technique\./
   );
   assert.equal(existsSync(join(STATE_DIR, 'review.lock')), false, 'lock released');
-  assert.equal(existsSync(join(STATE_DIR, 'staging')), false, 'staging cleaned up');
+  assert.equal(existsSync(stagingScratch), false, 'staging cleaned up');
+  assert.equal(existsSync(join(STATE_DIR, 'staging')), false, 'no staging left under the config dir');
   assert.match(readFileSync(join(STATE_DIR, 'review.log'), 'utf8'), /mode=review session=e2e rc=0/);
 });
 

--- a/skills/update-plugin/CHANGELOG.md
+++ b/skills/update-plugin/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the AgenticAI Plugin.
 Format: Machine-readable. Each version is a `## X.Y.Z` section.
 The agent parses this to show the delta between installed and current version.
 
+## 0.23.1
+
+- **autoskill: fix the background reviewer being unable to save anything (staging sat inside the write-blocked config dir).** The v0.22.0 port moved autoskill state under `${CLAUDE_CONFIG_DIR:-~/.claude}/`, which inadvertently placed the reviewer's `staging/` directory inside it — and Claude Code hard-blocks `Write`/`Edit` to anything under `~/.claude/` as a "sensitive file", independent of `--permission-mode`/`--allowedTools`. Every background review therefore ran to completion but silently saved nothing (each staging write hit a "sensitive file" error). The standalone prototype had kept staging outside `.claude` on purpose; this restores that.
+  - **Fix:** staging now lives in a fresh per-run `mkdtemp` directory under the OS temp dir (`STAGING_DIR` in `hooks/autoskill/lib.mjs`, `prepareStaging()` in `run-review.mjs`), created `0700` and unpredictable — outside the sensitive zone, per-run isolated (no machine-global path that breaks a second user with `EACCES` or lets a local user read / pre-plant staged skills, CWE-377), and exported via `AUTOSKILL_STAGING_DIR` so the reviewer's read-guard child cages the same directory. Persistent state, `learned.list`, logs, and the install target `~/.claude/skills/` stay under the config dir (written with Node `fs`, no guard).
+  - **Hardening:** the read-guard path cage now **canonicalizes** paths (`path.resolve` + separator-anchored prefix, case-folded on Windows) before the containment check, closing a path-traversal hole — `<staging>/../../…` previously passed the lexical `startsWith`, and once staging left `~/.claude` that could escape to real targets (home dotfiles, project files).
+  - **Tests:** regression coverage for all three invariants — staging never under the config dir, traversal denied, per-run `0700` staging honoring the env override. Discovered on the first real rollout; fix verified end-to-end (a real reviewer `Write` into the new staging location now succeeds where the old location was blocked).
+
 ## 0.23.0
 
 - **New: `grill-me` skill — relentless plan/decision stress-test.** New user-invoked command `/agenticaiplugin:grill-me [<topic>]` that interviews you one question at a time, walking the decision tree branch by branch and recommending an answer for each, until you reach shared understanding. Facts are looked up from the environment; decisions are put to you. Stateless (writes nothing) and manual-only (`disable-model-invocation: true`). Registered in the help overview and the CLAUDE.md command table.


### PR DESCRIPTION
## Problem

Since the v0.22.0 autoskill port, the background reviewer **ran to completion but silently saved nothing**. Root cause: the port moved autoskill state under `${CLAUDE_CONFIG_DIR:-~/.claude}/`, which placed the reviewer's `staging/` directory inside `~/.claude/`. Claude Code hard-blocks `Write`/`Edit` to anything under the config dir as a *"sensitive file"* — independent of `--permission-mode`/`--allowedTools`. Every staging write failed with a "sensitive file" error.

Observed live (3× in `review.log`):
> `mode=review … rc=0` — reviewer runs fine, then: *"jeder `Write`-Aufruf wird … mit 'sensitive file'-Permission-Fehler blockiert"*.

The standalone prototype kept staging outside `.claude` on purpose (`read-guard.sh` even comments *".claude/ ist von Claude Code selbst geschützt"*); the port regressed that.

## Fix

- **Staging out of the sensitive zone** — a fresh per-run `mkdtemp` dir (`0700`, unpredictable) under the OS temp dir (`STAGING_DIR` in `lib.mjs`, `prepareStaging()` in `run-review.mjs`), exported via `AUTOSKILL_STAGING_DIR` so the reviewer's read-guard child cages the same path. Persistent state, `learned.list`, logs and the install target `~/.claude/skills/` stay under the config dir (Node `fs`, no guard).
- **Path-cage hardening** (found by the review below) — the read-guard now **canonicalizes** paths (`path.resolve` + separator-anchored prefix, case-folded on Windows) before the containment check, closing a `<staging>/../../…` traversal that the lexical `startsWith` allowed and that the `~/.claude` block had previously masked.
- Per-run `mkdtemp` also removes the machine-global path that would break a second user with `EACCES` and let a local user read / pre-plant staged skills (CWE-377).

## Verification

- 68 `node --test` cases green, incl. **3 new regression tests**: staging never under the config dir, path-traversal denied, per-run `0700` staging (env override honored).
- **End-to-end:** a real `claude -p` reviewer `Write` into the new `/tmp` staging **succeeds**, where the old `~/.claude` location was blocked.
- This diff was itself run through `/agenticaiplugin:code-review`; its adversarial pass surfaced the traversal Critical and the multi-user/CWE-377 warnings — all fixed here in one round.

Bumps to **0.23.1** with a CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)